### PR TITLE
Retry sending QoS 1 outgoing publish messages

### DIFF
--- a/src/eventloop.rs
+++ b/src/eventloop.rs
@@ -124,6 +124,7 @@ where
         // requests staying longer than the retry interval, and handle their
         // retrial.
         for (pid, inflight) in self.state.retries(now, 50_000.milliseconds()) {
+            defmt::warn!("Retrying PID {:?}", pid);
             let packet = inflight
                 .packet(*pid, packet_buf)
                 .map_err(EventError::from)?;
@@ -712,7 +713,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore]
     fn retry_behaviour() {
         static mut Q: Queue<Request<Vec<u8, consts::U10>>, consts::U5, u8> =
             Queue(heapless::i::Queue::u8());

--- a/src/eventloop.rs
+++ b/src/eventloop.rs
@@ -126,7 +126,11 @@ where
         // By comparing the current time, select pending non-zero QoS publish
         // requests staying longer than the retry interval, and handle their
         // retrial.
-        for _publish in self.retries().into_iter() {}
+        for (pid, retry) in self.state.retries(now, 50_000.milliseconds()) {
+            let packet = retry.packet(*pid, packet_buf);
+            // *FIXME* second mutable borrow occurs here
+            /*self.send(network, packet)?;*/
+        }
 
         notification.ok_or(nb::Error::WouldBlock)
     }
@@ -349,10 +353,6 @@ where
                     })
             }
         }
-    }
-
-    fn retries(&mut self) -> Result<(), EventError> {
-        unimplemented!();
     }
 }
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -521,6 +521,10 @@ where
             last_touch,
         }
     }
+
+    pub(crate) fn last_touch_entry(&mut self) -> &mut StartTime<T> {
+        &mut self.last_touch
+    }
 }
 
 impl<P, T> Inflight<P, T>


### PR DESCRIPTION
Implement Retry logic for QoS1. QoS 2 not in scope of this PR.
First 3 commits introduce helper types. `NetworkHandle` is there only to make borrow checker happy.
4th commit implements the logic.