### PR TITLE
[Optional] Encapsulate network handling in NetworkHandle

### DIFF
--- a/src/eventloop.rs
+++ b/src/eventloop.rs
@@ -65,6 +65,7 @@ where
             EventError::Network(e)
         })? {
             self.network_connect(network)?;
+            self.state.connection_status = MqttConnectionStatus::Disconnected;
         }
 
         self.mqtt_connect(network).map_err(|e| {
@@ -241,8 +242,6 @@ where
         &mut self,
         network: &N,
     ) -> Result<(), EventError> {
-        self.state.connection_status = MqttConnectionStatus::Disconnected;
-
         self.network_handle.socket = network
             .socket()
             .map_err(|_e| EventError::Network(NetworkError::SocketOpen))?

--- a/src/eventloop.rs
+++ b/src/eventloop.rs
@@ -126,7 +126,11 @@ where
         // By comparing the current time, select pending non-zero QoS publish
         // requests staying longer than the retry interval, and handle their
         // retrial.
-        for _publish in self.retries().into_iter() {}
+        for (pid, retry) in self.state.retries(now, 50_000.milliseconds()) {
+            let packet = retry.packet(*pid, packet_buf);
+            // *FIXME* second mutable borrow occurs here
+            /*self.send(network, packet)?;*/
+        }
 
         notification.ok_or(nb::Error::WouldBlock)
     }
@@ -349,10 +353,6 @@ where
                     })
             }
         }
-    }
-
-    fn retries(&mut self) -> Result<(), EventError> {
-        unimplemented!();
     }
 }
 

--- a/src/eventloop.rs
+++ b/src/eventloop.rs
@@ -291,11 +291,7 @@ where
 
                 // mqtt connection with timeout
                 match self.network_handle.send(network, &connect.into()) {
-                    Ok(_) => {
-                        self.state
-                            .handle_outgoing_connect()
-                            .map_err(|e| nb::Error::Other(e.into()))?;
-                    }
+                    Ok(_) => self.state.handle_outgoing_connect(),
                     Err(e) => {
                         defmt::debug!("Disconnecting from send error!");
                         self.disconnect(network);

--- a/src/state.rs
+++ b/src/state.rs
@@ -339,9 +339,8 @@ where
         Ok(Unsubscribe::new(self.next_pid(), unsubscribe_request.topics).into())
     }
 
-    pub fn handle_outgoing_connect(&mut self) -> Result<(), StateError> {
+    pub(crate) fn handle_outgoing_connect(&mut self) {
         self.connection_status = MqttConnectionStatus::Handshake;
-        Ok(())
     }
 
     pub fn handle_incoming_connack(&mut self, connack: Connack) -> Result<(), StateError> {

--- a/src/state.rs
+++ b/src/state.rs
@@ -521,6 +521,10 @@ where
             last_touch,
         }
     }
+
+    pub(crate) fn last_touch_entry(&mut self) -> &mut StartTime<T> {
+        &mut self.last_touch
+    }
 }
 
 impl<P, T> Inflight<P, T>


### PR DESCRIPTION
This PR is optional. A dedicated struct for network handling 1. makes conditions
when `disconnect` is called explicit and 2. keeps the `network_connect` method
from opening and force-updating even when a closed socket is present.

PR #24 introduces `NetworkHandle`, a struct wrapping `TcpClient::TcpSocket` to
convince the borrow checker. By chance I found it was a nice place to organize
network handling methods. This PR consists of 3 groups of commits.
Cherry-picking some of them also makes me happy.

- First 2 commits are merely style changes and trivial.
- The 3rd commit makes it explicit when to call `disconnect` during MQTT's connection establishment step.
- 4 - 7 divides `network_connect` method into 4 pieces, since it would take on too many responsibilities.
- 8 - 11 just move methods to `NetworkHandle`.
