### PR TITLE
Reduce variant size in `Notification` by boxing `PublishNotification`

### DIFF
--- a/mqttrust_core/Cargo.toml
+++ b/mqttrust_core/Cargo.toml
@@ -22,7 +22,7 @@ embedded-hal = { version = "1.0.0-alpha.4" }
 embedded-nal = "0.6.0"
 embedded-time = "0.11.0"
 nb = "^1"
-heapless = { version = "^0.7", features = ["serde"] }
+heapless = { version = "^0.7", features = ["serde", "x86-sync-pool"] }
 mqttrust = { version = "^0.2.0", path = "../mqttrust" }
 # bbqueue = "0.4.12"
 bbqueue = { git = "https://github.com/mriise/bbqueue" }

--- a/mqttrust_core/src/eventloop.rs
+++ b/mqttrust_core/src/eventloop.rs
@@ -165,7 +165,7 @@ where
         // By comparing the current time, select pending non-zero QoS publish
         // requests staying longer than the retry interval, and handle their
         // retrial.
-        for (pid, inflight) in self.state.retries(now, 50_000.milliseconds()) {
+        for (pid, inflight) in self.state.retries(now, 10_000.milliseconds()) {
             mqtt_log!(warn, "Retrying PID {:?}", pid);
             // Update inflight's timestamp for later retrials
             inflight.last_touch_entry().insert(now);
@@ -221,7 +221,6 @@ where
                 self.state.last_ping_entry().insert(now);
 
                 self.state.await_pingresp = false;
-                self.state.outgoing_pub.clear();
                 self.network_handle.rx_buf.init();
 
                 let (username, password) = self.options.credentials();

--- a/mqttrust_core/src/lib.rs
+++ b/mqttrust_core/src/lib.rs
@@ -13,11 +13,12 @@ pub use client::Client;
 use core::convert::TryFrom;
 use embedded_time::clock;
 pub use eventloop::EventLoop;
+use heapless::pool::{singleton::Box, Init};
 use heapless::{String, Vec};
 pub use mqttrust::encoding::v4::{Pid, Publish, QoS, QosPid, Suback};
 pub use mqttrust::*;
 pub use options::{Broker, MqttOptions};
-use state::StateError;
+use state::{StateError, BOXED_PUBLISH};
 
 #[derive(Debug, PartialEq)]
 #[cfg_attr(feature = "defmt-impl", derive(defmt::Format))]
@@ -26,18 +27,18 @@ pub struct PublishNotification {
     pub qospid: QoS,
     pub retain: bool,
     pub topic_name: String<256>,
-    pub payload: Vec<u8, 2048>,
+    pub payload: Vec<u8, 1024>,
 }
 
 /// Includes incoming packets from the network and other interesting events
 /// happening in the eventloop
 #[derive(Debug, PartialEq)]
-#[cfg_attr(feature = "defmt-impl", derive(defmt::Format))]
+// #[cfg_attr(feature = "defmt-impl", derive(defmt::Format))]
 pub enum Notification {
     /// Incoming connection acknowledge
     ConnAck,
     /// Incoming publish from the broker
-    Publish(PublishNotification),
+    Publish(Box<BOXED_PUBLISH, Init>),
     /// Incoming puback from the broker
     Puback(Pid),
     /// Incoming pubrec from the broker

--- a/mqttrust_core/src/state.rs
+++ b/mqttrust_core/src/state.rs
@@ -85,6 +85,7 @@ where
             + core::mem::align_of::<PublishNotification>()
             - core::mem::size_of::<PublishNotification>()
                 % core::mem::align_of::<PublishNotification>();
+
         static mut PUBLISH_MEM: [u8; LEN] = [0u8; LEN];
         BOXED_PUBLISH::grow(unsafe { &mut PUBLISH_MEM });
 
@@ -485,10 +486,13 @@ impl<TIM, const L: usize> Inflight<TIM, L> {
 
 #[cfg(test)]
 mod test {
-    use super::{Milliseconds, MqttConnectionStatus, MqttState, Packet, StartTime, StateError};
+    use super::{
+        Milliseconds, MqttConnectionStatus, MqttState, Packet, StartTime, StateError, BOXED_PUBLISH,
+    };
     use crate::{packet::SerializedPacket, Notification};
     use core::convert::TryFrom;
     use embedded_time::{duration::Extensions, Clock, Instant};
+    use heapless::pool::singleton::Pool;
     use mqttrust::{
         encoding::v4::{decode_slice, encode_slice, Pid},
         Publish, QoS,
@@ -524,7 +528,11 @@ mod test {
     }
 
     fn build_mqttstate() -> MqttState<Milliseconds> {
-        MqttState::new()
+        let state = MqttState::new();
+        const LEN: usize = 1024 * 10;
+        static mut PUBLISH_MEM: [u8; LEN] = [0u8; LEN];
+        BOXED_PUBLISH::grow(unsafe { &mut PUBLISH_MEM });
+        state
     }
 
     #[test]
@@ -642,20 +650,6 @@ mod test {
         assert_eq!(publish_out.qos, QoS::AtLeastOnce);
         assert_eq!(publish_out.pid, Some(Pid::try_from(2).unwrap()));
         assert_eq!(mqtt.outgoing_pub.len(), 1);
-
-        let publish = Packet::Publish(build_publish(QoS::AtLeastOnce, None));
-        let len = encode_slice(&publish, buf).unwrap();
-        let mut pkg = SerializedPacket(&mut buf[..len]);
-
-        // Packet id should be incremented and publish should be saved in queue
-        mqtt.handle_outgoing_publish(&mut pkg, &now).unwrap();
-        let publish_out = match decode_slice(pkg.to_inner()).unwrap() {
-            Some(Packet::Publish(p)) => p,
-            _ => panic!(),
-        };
-        assert_eq!(publish_out.qos, QoS::AtLeastOnce);
-        assert_eq!(publish_out.pid, Some(Pid::try_from(3).unwrap()));
-        assert_eq!(mqtt.outgoing_pub.len(), 2);
     }
 
     #[test]
@@ -705,23 +699,16 @@ mod test {
         let mut pkg1 = SerializedPacket(&mut buf[..len]);
         mqtt.handle_outgoing_publish(&mut pkg1, &now).unwrap();
 
-        let publish2 = Packet::Publish(build_publish(QoS::ExactlyOnce, None));
-        let len = encode_slice(&publish2, buf).unwrap();
-        let mut pkg2 = SerializedPacket(&mut buf[..len]);
-        mqtt.handle_outgoing_publish(&mut pkg2, &now).unwrap();
-
-        mqtt.handle_incoming_puback(Pid::try_from(2).unwrap())
-            .unwrap();
         assert_eq!(mqtt.outgoing_pub.len(), 1);
 
-        let backup = mqtt.outgoing_pub.get_mut(&3).unwrap().packet(1).unwrap();
+        let backup = mqtt.outgoing_pub.get_mut(&2).unwrap().packet(1).unwrap();
         let publish_out = match decode_slice(backup).unwrap() {
             Some(Packet::Publish(p)) => p,
             _ => panic!(),
         };
-        assert_eq!(publish_out.qos, QoS::ExactlyOnce);
+        assert_eq!(publish_out.qos, QoS::AtLeastOnce);
 
-        mqtt.handle_incoming_puback(Pid::try_from(3).unwrap())
+        mqtt.handle_incoming_puback(Pid::try_from(2).unwrap())
             .unwrap();
         assert_eq!(mqtt.outgoing_pub.len(), 0);
     }
@@ -732,32 +719,18 @@ mod test {
         let buf = &mut [0u8; 256];
         let now = 0u32.milliseconds();
 
-        let publish1 = Packet::Publish(build_publish(QoS::AtLeastOnce, None));
-        let len = encode_slice(&publish1, buf).unwrap();
-        let mut pkg1 = SerializedPacket(&mut buf[..len]);
-        mqtt.handle_outgoing_publish(&mut pkg1, &now).unwrap();
+        let publish = Packet::Publish(build_publish(QoS::ExactlyOnce, None));
+        let len = encode_slice(&publish, buf).unwrap();
+        let mut pkg = SerializedPacket(&mut buf[..len]);
+        mqtt.handle_outgoing_publish(&mut pkg, &now).unwrap();
 
-        let publish2 = Packet::Publish(build_publish(QoS::ExactlyOnce, None));
-        let len = encode_slice(&publish2, buf).unwrap();
-        let mut pkg2 = SerializedPacket(&mut buf[..len]);
-        mqtt.handle_outgoing_publish(&mut pkg2, &now).unwrap();
-
-        mqtt.handle_incoming_pubrec(Pid::try_from(3).unwrap())
+        mqtt.handle_incoming_pubrec(Pid::try_from(2).unwrap())
             .unwrap();
-        assert_eq!(mqtt.outgoing_pub.len(), 1);
-
-        // check if the remaining element's pid is 2
-        let backup = mqtt.outgoing_pub.get_mut(&2).unwrap().packet(2).unwrap();
-        let publish_out = match decode_slice(backup).unwrap() {
-            Some(Packet::Publish(p)) => p,
-            _ => panic!(),
-        };
-        assert_eq!(publish_out.qos, QoS::AtLeastOnce);
-
+        assert_eq!(mqtt.outgoing_pub.len(), 0);
         assert_eq!(mqtt.outgoing_rel.len(), 1);
 
-        // check if the  element's pid is 3
-        assert!(mqtt.outgoing_rel.contains(&3));
+        // check if the  element's pid is 2
+        assert!(mqtt.outgoing_rel.contains(&2));
     }
 
     #[test]


### PR DESCRIPTION
- Reduce variant size in `Notification` by boxing `PublishNotification`
- Increase size of InFlight to allow full payload sizes plus mqtt overhead
- Reduce mqtt timeout from 50s to 10s before retrying packet
- Reduce number of InFlights allowed to 1