### PR TITLE
Add ?Sized trait bound to all places requiring embedded-nal traits

### DIFF
--- a/mqttrust/Cargo.toml
+++ b/mqttrust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mqttrust"
-version = "0.4.1-alpha0"
+version = "0.4.1-alpha.0"
 authors = ["Mathias Koch <mk@blackbird.online>"]
 description = "MQTT Client "
 readme = "../README.md"

--- a/mqttrust_core/Cargo.toml
+++ b/mqttrust_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mqttrust_core"
-version = "0.4.1-alpha0"
+version = "0.4.1-alpha.0"
 authors = ["Mathias Koch <mk@blackbird.online>"]
 description = "MQTT Client "
 readme = "../README.md"
@@ -23,7 +23,7 @@ embedded-nal = "0.6.0"
 embedded-time = "0.11.0"
 nb = "^1"
 heapless = { version = "^0.7", features = ["serde", "x86-sync-pool"] }
-mqttrust = { version = "^0.4.1-alpha0", path = "../mqttrust" }
+mqttrust = { version = "^0.4.1-alpha.0", path = "../mqttrust" }
 bbqueue = "0.5"
 
 log = { version = "^0.4", default-features = false, optional = true }

--- a/mqttrust_core/examples/linux.rs
+++ b/mqttrust_core/examples/linux.rs
@@ -1,7 +1,7 @@
 mod common;
 
 use mqttrust::{QoS, SubscribeTopic};
-use mqttrust_core::bbqueue::{BBBuffer, ConstBBBuffer};
+use mqttrust_core::bbqueue::BBBuffer;
 use mqttrust_core::Mqtt;
 use mqttrust_core::{EventLoop, MqttOptions, Notification};
 
@@ -9,7 +9,7 @@ use common::clock::SysClock;
 use common::network::Network;
 use std::thread;
 
-static mut Q: BBBuffer<{ 1024 * 6 }> = BBBuffer(ConstBBBuffer::new());
+static mut Q: BBBuffer<{ 1024 * 6 }> = BBBuffer::new();
 const MSG_CNT: u32 = 5;
 
 fn main() {

--- a/mqttrust_core/src/eventloop.rs
+++ b/mqttrust_core/src/eventloop.rs
@@ -46,7 +46,7 @@ where
         }
     }
 
-    pub fn connect<N: Dns + TcpClientStack<TcpSocket = S>>(
+    pub fn connect<N: Dns + TcpClientStack<TcpSocket = S> + ?Sized>(
         &mut self,
         network: &mut N,
     ) -> nb::Result<bool, EventError> {
@@ -108,7 +108,7 @@ where
 
     /// Selects an event from the client's requests, incoming packets from the
     /// broker and keepalive ping cycle.
-    fn select_event<N: TcpClientStack<TcpSocket = S>>(
+    fn select_event<N: TcpClientStack<TcpSocket = S> + ?Sized>(
         &mut self,
         network: &mut N,
     ) -> nb::Result<Notification, EventError> {
@@ -179,7 +179,7 @@ where
     /// Yields notification from events. All the error raised while processing
     /// event is reported as an `Ok` value of `Notification::Abort`.
     #[must_use = "Eventloop should be iterated over a loop to make progress"]
-    pub fn yield_event<N: TcpClientStack<TcpSocket = S>>(
+    pub fn yield_event<N: TcpClientStack<TcpSocket = S> + ?Sized>(
         &mut self,
         network: &mut N,
     ) -> nb::Result<Notification, Infallible> {
@@ -199,14 +199,14 @@ where
         })
     }
 
-    pub fn disconnect<N: TcpClientStack<TcpSocket = S>>(&mut self, network: &mut N) {
+    pub fn disconnect<N: TcpClientStack<TcpSocket = S> + ?Sized>(&mut self, network: &mut N) {
         self.state.connection_status = MqttConnectionStatus::Disconnected;
         if let Some(socket) = self.network_handle.socket.take() {
             network.close(socket).ok();
         }
     }
 
-    fn mqtt_connect<N: TcpClientStack<TcpSocket = S>>(
+    fn mqtt_connect<N: TcpClientStack<TcpSocket = S> + ?Sized>(
         &mut self,
         network: &mut N,
     ) -> nb::Result<bool, EventError> {
@@ -277,7 +277,7 @@ struct NetworkHandle<S> {
 }
 
 impl<S> NetworkHandle<S> {
-    fn lookup_host<N: Dns + TcpClientStack<TcpSocket = S>>(
+    fn lookup_host<N: Dns + TcpClientStack<TcpSocket = S> + ?Sized>(
         network: &mut N,
         broker: Broker,
         port: u16,
@@ -315,7 +315,7 @@ impl<S> NetworkHandle<S> {
 
     /// Checks if this socket is present and connected. Raises `NetworkError` when
     /// the socket is present and in its error state.
-    fn is_connected<N: Dns + TcpClientStack<TcpSocket = S>>(
+    fn is_connected<N: Dns + TcpClientStack<TcpSocket = S> + ?Sized>(
         &self,
         network: &mut N,
     ) -> Result<bool, NetworkError> {
@@ -327,7 +327,7 @@ impl<S> NetworkHandle<S> {
         }
     }
 
-    fn connect<N: Dns + TcpClientStack<TcpSocket = S>>(
+    fn connect<N: Dns + TcpClientStack<TcpSocket = S> + ?Sized>(
         &mut self,
         network: &mut N,
         socket_addr: SocketAddr,
@@ -346,7 +346,7 @@ impl<S> NetworkHandle<S> {
         })
     }
 
-    pub fn send_packet<'d, N: TcpClientStack<TcpSocket = S>>(
+    pub fn send_packet<'d, N: TcpClientStack<TcpSocket = S> + ?Sized>(
         &mut self,
         network: &mut N,
         pkt: &Packet,
@@ -371,7 +371,7 @@ impl<S> NetworkHandle<S> {
         Ok(length)
     }
 
-    pub fn send<'d, N: TcpClientStack<TcpSocket = S>>(
+    pub fn send<'d, N: TcpClientStack<TcpSocket = S> + ?Sized>(
         &mut self,
         network: &mut N,
         pkt: &[u8],
@@ -389,7 +389,7 @@ impl<S> NetworkHandle<S> {
         Ok(length)
     }
 
-    fn receive<N: TcpClientStack<TcpSocket = S>>(
+    fn receive<N: TcpClientStack<TcpSocket = S> + ?Sized>(
         &mut self,
         network: &mut N,
     ) -> nb::Result<PacketDecoder<'_>, NetworkError> {
@@ -449,7 +449,7 @@ impl PacketBuffer {
     /// bytes found, the range gets extended covering them.
     fn receive<N, S>(&mut self, socket: &mut S, network: &mut N) -> nb::Result<(), NetworkError>
     where
-        N: TcpClientStack<TcpSocket = S>,
+        N: TcpClientStack<TcpSocket = S> + ?Sized,
     {
         let buffer = self.buffer();
         let len = network.receive(socket, buffer).map_err(|e| {

--- a/mqttrust_core/src/state.rs
+++ b/mqttrust_core/src/state.rs
@@ -5,10 +5,7 @@ use crate::PublishNotification;
 use core::convert::TryInto;
 use core::ops::Add;
 use embedded_time::duration::Milliseconds;
-use heapless::{
-    pool,
-    pool::singleton::Pool,
-};
+use heapless::{pool, pool::singleton::Pool};
 use heapless::{FnvIndexMap, FnvIndexSet, IndexMap, IndexSet};
 use mqttrust::encoding::v4::*;
 


### PR DESCRIPTION
Add ?Sized trait bound to all places requiring embedded-nal traits, to relax sized requirement of mutable reference.

I recently ran into an issue where i had a closure of signature `F: FnOnce(&mut dyn TcpClientStack<TcpSocket = Handle, Error = Error>)`, which removes the sized property of the `TcpClientStack` implementor.

This means that a `&mut dyn TcpClientStack<TcpSocket = Handle, Error = Error>` cannot be used in places like `fn foo<T: TcpClientStack>(network: &mut T) { ... }` without relaxing the requirement on `Sized` as `fn foo<T: TcpClientStack + ?Sized>(network: &mut T) { ... }`.

This PR adds those `?Sized`, as we are not storing the references anywhere anyways.