### PR TITLE
add release_queue() to Client and Eventloop

### DIFF
--- a/mqttrust/src/lib.rs
+++ b/mqttrust/src/lib.rs
@@ -12,9 +12,12 @@ pub use encoding::v4::{
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(feature = "defmt-impl", derive(defmt::Format))]
 pub enum MqttError {
+    /// Queue full, cannot send/receive more packets
     Full,
+    /// RefCell borrow fault
     Borrow,
-    Overflow,
+    /// Needed resource is unavailable
+    Unavailable,
 }
 
 pub trait Mqtt {

--- a/mqttrust_core/src/client.rs
+++ b/mqttrust_core/src/client.rs
@@ -23,14 +23,24 @@ use mqttrust::{
 ///   event loop. Length in number of request packets
 pub struct Client<'a, 'b, const L: usize> {
     client_id: &'b str,
-    producer: RefCell<FrameProducer<'a, L>>,
+    producer: Option<RefCell<FrameProducer<'a, L>>>,
 }
 
 impl<'a, 'b, const L: usize> Client<'a, 'b, L> {
     pub fn new(producer: FrameProducer<'a, L>, client_id: &'b str) -> Self {
         Self {
             client_id,
-            producer: RefCell::new(producer),
+            producer: Some(RefCell::new(producer)),
+        }
+    }
+
+    /// Release `FrameProducer`
+    ///
+    /// This can be used before dropping `Client` to get back original `FrameProducer`.
+    pub fn release_producer(&mut self) -> Option<FrameProducer<'a, L>> {
+        match self.producer.take() {
+            Some(prod) => Some(prod.into_inner()),
+            None => None,
         }
     }
 }
@@ -41,18 +51,16 @@ impl<'a, 'b, const L: usize> Mqtt for Client<'a, 'b, L> {
     }
 
     fn send(&self, packet: Packet<'_>) -> Result<(), MqttError> {
-        let mut prod = self
-            .producer
-            .try_borrow_mut()
-            .map_err(|_| MqttError::Borrow)?;
-
-        let max_size = packet.len();
-        let mut grant = prod.grant(max_size).map_err(|_| MqttError::Full)?;
-
-        let len = encode_slice(&packet, grant.deref_mut()).map_err(|_| MqttError::Full)?;
-
-        grant.commit(len);
-
-        Ok(())
+        match &self.producer {
+            Some(producer) => {
+                let mut prod = producer.try_borrow_mut().map_err(|_| MqttError::Borrow)?;
+                let max_size = packet.len();
+                let mut grant = prod.grant(max_size).map_err(|_| MqttError::Full)?;
+                let len = encode_slice(&packet, grant.deref_mut()).map_err(|_| MqttError::Full)?;
+                grant.commit(len);
+                Ok(())
+            }
+            None => Err(MqttError::Unavailable),
+        }
     }
 }

--- a/mqttrust_core/src/client.rs
+++ b/mqttrust_core/src/client.rs
@@ -36,8 +36,8 @@ impl<'a, 'b, const L: usize> Client<'a, 'b, L> {
 
     /// Release `FrameProducer`
     ///
-    /// This can be used before dropping `Client` to get back original `FrameProducer`.
-    pub fn release_producer(&mut self) -> Option<FrameProducer<'a, L>> {
+    /// This can be called before dropping `Client` to get back original `FrameProducer`.
+    pub fn release_queue(&mut self) -> Option<FrameProducer<'a, L>> {
         match self.producer.take() {
             Some(prod) => Some(prod.into_inner()),
             None => None,

--- a/mqttrust_core/src/eventloop.rs
+++ b/mqttrust_core/src/eventloop.rs
@@ -46,8 +46,8 @@ where
 
     /// Release `FrameConsumer`
     ///
-    /// This can be used before dropping `EventLoop` to get back original `FrameConsumer`.
-    pub fn release_consumer(&mut self) -> Option<FrameConsumer<'a, L>> {
+    /// This can be called before dropping `EventLoop` to get back original `FrameConsumer`.
+    pub fn release_queue(&mut self) -> Option<FrameConsumer<'a, L>> {
         self.requests.take()
     }
 

--- a/mqttrust_core/src/lib.rs
+++ b/mqttrust_core/src/lib.rs
@@ -88,6 +88,7 @@ pub enum EventError {
     Network(NetworkError),
     BufferSize,
     Clock,
+    RequestsNotAvailable,
 }
 
 #[derive(Debug, PartialEq)]


### PR DESCRIPTION
This PR adds `Client::release_queue()` and `Eventloop::release_queue()`.
Those can be called before dropping Client and Eventloop to get back original producer and consumer that can be given back to BBQueue after that.
Useful when you want to reinit everything from scratch.

```rust
let prod = mqtt_client.release_queue().unwrap();
let cons = mqtt_eventloop.release_queue().unwrap();
mqtt_queue.try_release_framed(prod, cons);

drop(mqtt_client);
drop(mqtt_eventloop);
```